### PR TITLE
Add React UI for managing stylization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Image Resizing using AWS S3, Lambda, and SNS
 
-This project demonstrates how to automatically resize images uploaded to an S3 bucket using AWS Lambda and notify via SNS.
+This project demonstrates how to automatically stylize images uploaded to an S3 bucket using AWS Lambda and notify via SNS.
 
 ## Prerequisites
 
 - AWS Account
 - AWS CLI configured
 - Python 3.x
+- Node.js 18+
 - Boto3 library
 - Pillow library
 
@@ -43,9 +44,29 @@ This project demonstrates how to automatically resize images uploaded to an S3 b
 ## Usage
 
 1. **Upload an image to the `image-non-sized-1` bucket.**
-2. The Lambda function will automatically resize and compress the image.
-3. The resized image will be uploaded to the `image-sized-1` bucket.
-4. A notification will be sent to the SNS topic.
+2. The Lambda function will automatically detect whether the image is grayscale or color.
+3. Grayscale uploads are colorized, while color images are cartoonized with preserved transparency.
+4. The stylized image is uploaded to the `image-sized-1` bucket under a `stylized/` prefix.
+5. A notification is sent to the SNS topic summarizing the transformation.
+
+## Frontend control panel
+
+A React single-page application is available under `frontend/` to drive the Lambda workflow from the browser. It supports:
+
+- Uploading images directly to the source bucket using SigV4-signed requests.
+- Polling the destination bucket for the stylized output and presenting it in the UI.
+- Tracking progress with a real-time activity log and status updates.
+- Supplying optional metadata that records the desired transformation preference.
+
+To run the UI locally:
+
+```sh
+cd frontend
+npm install
+npm run dev
+```
+
+The development server listens on [http://localhost:5173](http://localhost:5173). Provide temporary AWS credentials with access to both buckets when prompted by the UI. For production deployments, host the compiled assets produced by `npm run build` behind an authenticated origin.
 
 ## License
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stylize Images</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stylizer-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,250 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useStylizeWorkflow } from './hooks/useStylizeWorkflow.js';
+import SectionCard from './components/SectionCard.jsx';
+import ActivityLog from './components/ActivityLog.jsx';
+import FilePreview from './components/FilePreview.jsx';
+
+const TRANSFORM_OPTIONS = [
+  { value: 'auto', label: 'Auto-detect (color images cartoonized, grayscale colorized)' },
+  { value: 'cartoon', label: 'Force cartoonize' },
+  { value: 'colorize', label: 'Force colorize' },
+];
+
+const BUSY_STATUSES = new Set(['preparing', 'uploading', 'waiting', 'downloading']);
+
+export default function App() {
+  const [region, setRegion] = useState('');
+  const [accessKeyId, setAccessKeyId] = useState('');
+  const [secretAccessKey, setSecretAccessKey] = useState('');
+  const [sessionToken, setSessionToken] = useState('');
+  const [inputBucket, setInputBucket] = useState('');
+  const [outputBucket, setOutputBucket] = useState('');
+  const [inputPrefix, setInputPrefix] = useState('uploads/');
+  const [outputPrefix, setOutputPrefix] = useState('stylized/');
+  const [transformation, setTransformation] = useState('auto');
+  const [file, setFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+
+  const { status, statusMessage, log, resultUrl, resultContentType, start, reset } =
+    useStylizeWorkflow();
+
+  const busy = useMemo(() => BUSY_STATUSES.has(status), [status]);
+
+  useEffect(() => {
+    if (!file) {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+      return undefined;
+    }
+
+    const newUrl = URL.createObjectURL(file);
+    setPreviewUrl((previous) => {
+      if (previous) {
+        URL.revokeObjectURL(previous);
+      }
+      return newUrl;
+    });
+
+    return () => {
+      URL.revokeObjectURL(newUrl);
+    };
+  }, [file]);
+
+  const handleFileChange = (event) => {
+    const nextFile = event.target.files && event.target.files[0];
+    setFile(nextFile || null);
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    start({
+      file,
+      region,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      inputBucket,
+      outputBucket,
+      transformation,
+      inputPrefix,
+      outputPrefix,
+    });
+  };
+
+  const handleReset = () => {
+    reset();
+    setFile(null);
+    setTransformation('auto');
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Stylize Images with Lambda</h1>
+        <p>
+          Upload a source photo to your S3 bucket and let the Lambda function automatically
+          cartoonize or colorize it. Provide temporary AWS credentials tied to a role with
+          access to both the source and destination buckets.
+        </p>
+      </header>
+
+      <main>
+        <form className="layout-grid" onSubmit={handleSubmit}>
+          <SectionCard title="AWS credentials">
+            <p className="section-hint">
+              Use short-lived IAM credentials (such as from AWS SSO or STS) when testing from
+              the browser.
+            </p>
+            <label className="field">
+              <span>Region</span>
+              <input
+                type="text"
+                value={region}
+                onChange={(event) => setRegion(event.target.value)}
+                placeholder="ap-south-1"
+                required
+              />
+            </label>
+            <label className="field">
+              <span>Access key ID</span>
+              <input
+                type="text"
+                value={accessKeyId}
+                onChange={(event) => setAccessKeyId(event.target.value)}
+                required
+              />
+            </label>
+            <label className="field">
+              <span>Secret access key</span>
+              <input
+                type="password"
+                value={secretAccessKey}
+                onChange={(event) => setSecretAccessKey(event.target.value)}
+                required
+              />
+            </label>
+            <label className="field">
+              <span>Session token (optional)</span>
+              <input
+                type="password"
+                value={sessionToken}
+                onChange={(event) => setSessionToken(event.target.value)}
+              />
+            </label>
+          </SectionCard>
+
+          <SectionCard title="S3 buckets">
+            <p className="section-hint">
+              The Lambda function listens to uploads in the source bucket and stores stylized
+              results in the destination bucket under a stylized prefix.
+            </p>
+            <label className="field">
+              <span>Source bucket</span>
+              <input
+                type="text"
+                value={inputBucket}
+                onChange={(event) => setInputBucket(event.target.value)}
+                placeholder="image-non-sized-1"
+                required
+              />
+            </label>
+            <label className="field">
+              <span>Upload prefix</span>
+              <input
+                type="text"
+                value={inputPrefix}
+                onChange={(event) => setInputPrefix(event.target.value)}
+                placeholder="uploads/"
+              />
+            </label>
+            <label className="field">
+              <span>Destination bucket</span>
+              <input
+                type="text"
+                value={outputBucket}
+                onChange={(event) => setOutputBucket(event.target.value)}
+                placeholder="image-sized-1"
+                required
+              />
+            </label>
+            <label className="field">
+              <span>Stylized prefix</span>
+              <input
+                type="text"
+                value={outputPrefix}
+                onChange={(event) => setOutputPrefix(event.target.value)}
+                placeholder="stylized/"
+              />
+            </label>
+          </SectionCard>
+
+          <SectionCard title="Upload">
+            <label className="field">
+              <span>Choose an image</span>
+              <input type="file" accept="image/*" onChange={handleFileChange} />
+            </label>
+            <label className="field">
+              <span>Transformation preference</span>
+              <select
+                value={transformation}
+                onChange={(event) => setTransformation(event.target.value)}
+              >
+                {TRANSFORM_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <p className="section-hint">
+              The Lambda will automatically inspect the image. Setting a preference stores it as
+              object metadata for observability and future overrides.
+            </p>
+            <div className="button-row">
+              <button type="submit" disabled={busy}>
+                {busy ? 'Working…' : 'Start stylizing'}
+              </button>
+              <button type="button" onClick={handleReset} disabled={busy && status !== 'error'}>
+                Reset
+              </button>
+            </div>
+            <div className="status-pill" data-status={status}>
+              <span>Status:</span>
+              <strong>{statusMessage}</strong>
+            </div>
+          </SectionCard>
+        </form>
+
+        <section className="results-grid">
+          <SectionCard title="Source preview">
+            <FilePreview url={previewUrl} name={file?.name} emptyHint="No image selected yet." />
+          </SectionCard>
+          <SectionCard title="Stylized output">
+            {status === 'complete' && resultUrl ? (
+              <FilePreview
+                url={resultUrl}
+                name={file?.name ? `stylized-${file.name}` : 'stylized-image'}
+                mimeType={resultContentType}
+                emptyHint="Upload an image to see the stylized result."
+              />
+            ) : (
+              <p className="empty-placeholder">Upload an image to see the stylized result.</p>
+            )}
+          </SectionCard>
+          <SectionCard title="Activity log">
+            <ActivityLog entries={log} />
+          </SectionCard>
+        </section>
+      </main>
+
+      <footer className="app-footer">
+        <p>
+          The UI signs requests with AWS Signature Version 4 directly in the browser. Always use
+          temporary credentials and revoke them after use.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/aws/createS3Client.js
+++ b/frontend/src/aws/createS3Client.js
@@ -1,0 +1,235 @@
+const EMPTY_PAYLOAD_SHA256 =
+  'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+function toHex(buffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((value) => value.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function sha256Hex(data) {
+  const encoder = new TextEncoder();
+  let buffer;
+  if (typeof data === 'string') {
+    buffer = encoder.encode(data);
+  } else if (data instanceof ArrayBuffer) {
+    buffer = new Uint8Array(data);
+  } else if (ArrayBuffer.isView(data)) {
+    buffer = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  } else if (data && typeof data.arrayBuffer === 'function') {
+    buffer = new Uint8Array(await data.arrayBuffer());
+  } else if (!data) {
+    buffer = new Uint8Array();
+  } else {
+    throw new Error('Unsupported data type for hashing.');
+  }
+
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  return toHex(hashBuffer);
+}
+
+async function hmacKey(key, data) {
+  return crypto.subtle.sign(
+    'HMAC',
+    await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']),
+    data
+  );
+}
+
+async function deriveSigningKey(secretAccessKey, dateStamp, region, service) {
+  const encoder = new TextEncoder();
+  const kSecret = encoder.encode(`AWS4${secretAccessKey}`);
+  const kDate = await hmacKey(kSecret, encoder.encode(dateStamp));
+  const kRegion = await hmacKey(kDate, encoder.encode(region));
+  const kService = await hmacKey(kRegion, encoder.encode(service));
+  return hmacKey(kService, encoder.encode('aws4_request'));
+}
+
+function formatAmzDate(date) {
+  const pad = (value, size = 2) => value.toString().padStart(size, '0');
+  const year = date.getUTCFullYear();
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  const hours = pad(date.getUTCHours());
+  const minutes = pad(date.getUTCMinutes());
+  const seconds = pad(date.getUTCSeconds());
+  return {
+    amzDate: `${year}${month}${day}T${hours}${minutes}${seconds}Z`,
+    dateStamp: `${year}${month}${day}`,
+  };
+}
+
+function encodeS3Key(key) {
+  return key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+    .replace(/%2F/g, '/');
+}
+
+function buildCanonicalHeaders(headers) {
+  return Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), value])
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `${name}:${value.toString().trim()}`)
+    .join('\n');
+}
+
+function buildSignedHeaders(headers) {
+  return Object.keys(headers)
+    .map((name) => name.toLowerCase())
+    .sort()
+    .join(';');
+}
+
+async function signRequest({
+  method,
+  bucket,
+  region,
+  key,
+  headers = {},
+  body,
+  accessKeyId,
+  secretAccessKey,
+  sessionToken,
+}) {
+  const service = 's3';
+  const host = `${bucket}.s3.${region}.amazonaws.com`;
+  const { amzDate, dateStamp } = formatAmzDate(new Date());
+
+  const payloadHash = body ? await sha256Hex(body) : EMPTY_PAYLOAD_SHA256;
+  const mergedHeaders = {
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+    ...headers,
+  };
+
+  if (sessionToken) {
+    mergedHeaders['x-amz-security-token'] = sessionToken;
+  }
+
+  const canonicalHeaders = buildCanonicalHeaders(mergedHeaders);
+  const signedHeaders = buildSignedHeaders(mergedHeaders);
+  const canonicalRequest = [
+    method.toUpperCase(),
+    `/${encodeS3Key(key)}`,
+    '',
+    `${canonicalHeaders}\n`,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = `AWS4-HMAC-SHA256\n${amzDate}\n${credentialScope}\n${await sha256Hex(
+    canonicalRequest
+  )}`;
+
+  const signingKey = await deriveSigningKey(secretAccessKey, dateStamp, region, service);
+  const signatureBytes = await hmacKey(signingKey, new TextEncoder().encode(stringToSign));
+  const signature = toHex(signatureBytes);
+
+  const authorization = `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    url: `https://${host}/${encodeS3Key(key)}`,
+    headers: {
+      ...mergedHeaders,
+      Authorization: authorization,
+    },
+    body,
+  };
+}
+
+async function makeRequest(config) {
+  const { method, body } = config;
+  const payload = body && typeof body.arrayBuffer === 'function' ? await body.arrayBuffer() : body;
+  const signed = await signRequest({ ...config, body: payload });
+  const response = await fetch(signed.url, {
+    method,
+    headers: signed.headers,
+    body: payload || undefined,
+  });
+
+  if (!response.ok) {
+    const error = new Error(`S3 request failed with status ${response.status}`);
+    error.response = response;
+    throw error;
+  }
+
+  return response;
+}
+
+export function createS3Client({ region, accessKeyId, secretAccessKey, sessionToken }) {
+  if (!region) {
+    throw new Error('Region is required to create an S3 client.');
+  }
+
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error('Access key ID and secret access key are required.');
+  }
+
+  return {
+    async putObject({ Bucket: bucket, Key: key, Body: body, ContentType, Metadata }) {
+      const headers = {};
+      if (ContentType) {
+        headers['Content-Type'] = ContentType;
+      }
+      if (Metadata) {
+        for (const [metaKey, metaValue] of Object.entries(Metadata)) {
+          headers[`x-amz-meta-${metaKey.toLowerCase()}`] = metaValue;
+        }
+      }
+      await makeRequest({
+        method: 'PUT',
+        bucket,
+        region,
+        key,
+        headers,
+        body,
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+      });
+    },
+
+    async headObject({ Bucket: bucket, Key: key }) {
+      const response = await makeRequest({
+        method: 'HEAD',
+        bucket,
+        region,
+        key,
+        headers: {},
+        body: null,
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+      });
+      return { headers: response.headers, status: response.status };
+    },
+
+    async getObject({ Bucket: bucket, Key: key }) {
+      const response = await makeRequest({
+        method: 'GET',
+        bucket,
+        region,
+        key,
+        headers: {},
+        body: null,
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+      });
+      const arrayBuffer = await response.arrayBuffer();
+      const contentType = response.headers.get('content-type');
+      return {
+        Body: {
+          async transformToByteArray() {
+            return new Uint8Array(arrayBuffer);
+          },
+        },
+        ContentType: contentType,
+      };
+    },
+  };
+}

--- a/frontend/src/components/ActivityLog.jsx
+++ b/frontend/src/components/ActivityLog.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ActivityLog({ entries }) {
+  if (!entries || entries.length === 0) {
+    return <p className="empty-placeholder">No activity yet.</p>;
+  }
+
+  return (
+    <ol className="activity-log">
+      {entries.map((entry) => (
+        <li key={entry.id}>
+          <span className="activity-timestamp">{entry.timestamp}</span>
+          <span className="activity-message">{entry.message}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/components/FilePreview.jsx
+++ b/frontend/src/components/FilePreview.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default function FilePreview({ url, name, mimeType, emptyHint }) {
+  if (!url) {
+    return <p className="empty-placeholder">{emptyHint}</p>;
+  }
+
+  const isImage = mimeType ? mimeType.startsWith('image/') : true;
+  const filename = name || 'preview-image';
+
+  return (
+    <div className="file-preview">
+      {isImage ? (
+        <img src={url} alt={filename} />
+      ) : (
+        <p className="empty-placeholder">
+          The stylized file is not an image preview.{' '}
+          <a href={url} download={filename}>
+            Download {filename}
+          </a>
+        </p>
+      )}
+      <div className="file-preview-footer">
+        <a href={url} download={filename}>
+          Download {filename}
+        </a>
+        {mimeType ? <span className="file-preview-meta">{mimeType}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SectionCard.jsx
+++ b/frontend/src/components/SectionCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function SectionCard({ title, children }) {
+  return (
+    <section className="section-card">
+      <header>
+        <h2>{title}</h2>
+      </header>
+      <div className="section-content">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useStylizeWorkflow.js
+++ b/frontend/src/hooks/useStylizeWorkflow.js
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createS3Client } from '../aws/createS3Client.js';
+
+const DEFAULT_INPUT_PREFIX = 'uploads/';
+const DEFAULT_OUTPUT_PREFIX = 'stylized/';
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 24; // Poll for up to 2 minutes.
+
+function toLogEntry(message) {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date().toLocaleTimeString(),
+    message,
+  };
+}
+
+export function useStylizeWorkflow() {
+  const [status, setStatus] = useState('idle');
+  const [log, setLog] = useState([]);
+  const [resultUrl, setResultUrl] = useState(null);
+  const [resultContentType, setResultContentType] = useState(null);
+  const abortRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+      if (resultUrl) {
+        URL.revokeObjectURL(resultUrl);
+      }
+    };
+  }, [resultUrl]);
+
+  const appendLog = useCallback((message) => {
+    setLog((previous) => [...previous, toLogEntry(message)]);
+  }, []);
+
+  const reset = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    setStatus('idle');
+    setLog([]);
+    if (resultUrl) {
+      URL.revokeObjectURL(resultUrl);
+      setResultUrl(null);
+    }
+    setResultContentType(null);
+  }, [resultUrl]);
+
+  const start = useCallback(
+    async ({
+      file,
+      region,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      inputBucket,
+      outputBucket,
+      transformation,
+      inputPrefix,
+      outputPrefix,
+    }) => {
+      if (!file) {
+        appendLog('Please choose an image to upload.');
+        return;
+      }
+
+      setStatus('preparing');
+      appendLog(`Preparing to upload ${file.name}`);
+
+      if (!region || !accessKeyId || !secretAccessKey) {
+        appendLog('Region, access key ID, and secret access key are required.');
+        setStatus('error');
+        return;
+      }
+
+      if (!inputBucket?.trim()) {
+        appendLog('Please provide the source bucket that triggers the Lambda.');
+        setStatus('error');
+        return;
+      }
+
+      if (!outputBucket?.trim()) {
+        appendLog('Please provide the destination bucket for stylized assets.');
+        setStatus('error');
+        return;
+      }
+
+      const client = createS3Client({ region, accessKeyId, secretAccessKey, sessionToken });
+      const sourceBucket = inputBucket.trim();
+      const destinationBucket = outputBucket.trim();
+      const normalizedInputPrefix = (inputPrefix || DEFAULT_INPUT_PREFIX).trim();
+      const rawPrefix =
+        normalizedInputPrefix === '' ? '' : normalizedInputPrefix.replace(/^\/+/, '');
+      const uploadPrefix =
+        rawPrefix === '' ? '' : rawPrefix.endsWith('/') ? rawPrefix : `${rawPrefix}/`;
+      const baseName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const uniqueId = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}`;
+      const objectKey = `${uploadPrefix}${uniqueId}-${baseName}`;
+
+      const metadata = {};
+      if (transformation && transformation !== 'auto') {
+        metadata['stylize-preference'] = transformation;
+      }
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        setStatus('uploading');
+        appendLog(`Uploading to s3://${sourceBucket}/${objectKey}`);
+        await client.putObject({
+          Bucket: sourceBucket,
+          Key: objectKey,
+          Body: file,
+          ContentType: file.type || 'application/octet-stream',
+          Metadata: Object.keys(metadata).length ? metadata : undefined,
+        });
+      } catch (error) {
+        setStatus('error');
+        appendLog(`Upload failed: ${error.message}`);
+        abortRef.current = null;
+        return;
+      }
+
+      const normalizedOutputPrefix = (outputPrefix || DEFAULT_OUTPUT_PREFIX).trim();
+      const rawOutputPrefix =
+        normalizedOutputPrefix === '' ? '' : normalizedOutputPrefix.replace(/^\/+/, '');
+      const outputKeyPrefix =
+        rawOutputPrefix === '' ? '' : rawOutputPrefix.endsWith('/') ? rawOutputPrefix : `${rawOutputPrefix}/`;
+      const outputKey = `${outputKeyPrefix}${objectKey}`;
+
+      setStatus('waiting');
+      appendLog('Upload complete. Waiting for stylized output...');
+
+      let attempt = 0;
+      while (attempt < MAX_POLLS) {
+        if (controller.signal.aborted) {
+          appendLog('Workflow aborted by user.');
+          setStatus('idle');
+          abortRef.current = null;
+          return;
+        }
+
+        attempt += 1;
+        appendLog(`Checking for stylized asset (attempt ${attempt}/${MAX_POLLS})`);
+        try {
+          const headResult = await client.headObject({ Bucket: destinationBucket, Key: outputKey });
+          appendLog('Stylized asset found. Downloading...');
+          setStatus('downloading');
+          const getResult = await client.getObject({ Bucket: destinationBucket, Key: outputKey });
+          const arrayBuffer = await getResult.Body?.transformToByteArray();
+          if (!arrayBuffer) {
+            throw new Error('Unable to read stylized image body.');
+          }
+          const mimeType =
+            getResult.ContentType || headResult.headers?.get?.('content-type') || 'image/jpeg';
+          const blob = new Blob([arrayBuffer], { type: mimeType });
+          if (resultUrl) {
+            URL.revokeObjectURL(resultUrl);
+          }
+          const newUrl = URL.createObjectURL(blob);
+          setResultUrl(newUrl);
+          setResultContentType(mimeType);
+          appendLog('Stylized image downloaded successfully.');
+          setStatus('complete');
+          abortRef.current = null;
+          return;
+        } catch (error) {
+          const statusCode = error?.response?.status || error?.$metadata?.httpStatusCode;
+          if (statusCode === 404) {
+            // Not ready yet.
+          } else {
+            setStatus('error');
+            appendLog(`Failed to retrieve stylized image: ${error.message}`);
+            abortRef.current = null;
+            return;
+          }
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      }
+
+      setStatus('error');
+      appendLog('Timed out waiting for stylized image.');
+      abortRef.current = null;
+    },
+    [appendLog, resultUrl]
+  );
+
+  const statusMessage = useMemo(() => {
+    switch (status) {
+      case 'idle':
+        return 'Idle';
+      case 'preparing':
+        return 'Preparing upload';
+      case 'uploading':
+        return 'Uploading source image';
+      case 'waiting':
+        return 'Waiting for Lambda to finish';
+      case 'downloading':
+        return 'Downloading stylized image';
+      case 'complete':
+        return 'Complete';
+      case 'error':
+        return 'Error';
+      default:
+        return status;
+    }
+  }, [status]);
+
+  return {
+    status,
+    statusMessage,
+    log,
+    resultUrl,
+    resultContentType,
+    start,
+    reset,
+  };
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,245 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f5f7;
+  color: #1c1c1e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f6f9fc 0%, #eef1f7 100%);
+}
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+}
+
+.app-header p {
+  margin: 0;
+  color: #3a3a3c;
+  line-height: 1.5;
+}
+
+.layout-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-card {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-card header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.section-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #5f6368;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.field input,
+.field select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button-row button {
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.button-row button[type='submit'] {
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  color: white;
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.28);
+}
+
+.button-row button[type='submit']:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button-row button[type='submit']:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+
+.button-row button[type='button'] {
+  background: rgba(99, 102, 241, 0.08);
+  color: #3730a3;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.status-pill[data-status='complete'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.status-pill[data-status='error'] {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.results-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.file-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.file-preview img {
+  width: 100%;
+  border-radius: 12px;
+  object-fit: contain;
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.15);
+}
+
+.file-preview-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.file-preview-footer a {
+  color: #4f46e5;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.file-preview-footer a:hover {
+  text-decoration: underline;
+}
+
+.file-preview-meta {
+  font-family: 'Fira Code', Menlo, monospace;
+  background: rgba(79, 70, 229, 0.1);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+
+.activity-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.activity-log li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(226, 232, 240, 0.55);
+}
+
+.activity-timestamp {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.activity-message {
+  color: #1f2937;
+}
+
+.empty-placeholder {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.app-footer {
+  text-align: center;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .section-card {
+    padding: 1.25rem;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  esbuild: {
+    jsxFactory: 'React.createElement',
+    jsxFragment: 'React.Fragment',
+  },
+  server: {
+    port: 5173,
+    host: true
+  }
+});

--- a/image-resizing-s3.py
+++ b/image-resizing-s3.py
@@ -1,59 +1,267 @@
-import os
-import boto3
-from PIL import Image
-from io import BytesIO
+"""Stylize uploaded images into cartoons or colorized versions and notify SNS."""
 
-# Initialize AWS clients
-s3 = boto3.client('s3')
-sns = boto3.client('sns')
+from __future__ import annotations
+
+import logging
+from io import BytesIO
+from typing import Optional, Tuple
+
+import boto3
+from botocore.exceptions import ClientError
+from PIL import Image, ImageChops, ImageEnhance, ImageFile, ImageFilter, ImageOps
+
+# Allow Pillow to load truncated images instead of raising an exception. Lambda
+# functions often process images that may be partially uploaded when the event
+# fires. Pillow recommends enabling this flag in such environments.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+logger = logging.getLogger(__name__)
+
+# Initialize AWS clients once so that Lambda can reuse connections between
+# invocations. This reduces cold-start latency and improves overall throughput.
+s3 = boto3.client("s3")
+sns = boto3.client("sns")
 
 # Define the S3 buckets and SNS topic
-bucket_1 = 'image-non-sized-1' # your-source-bucket
-bucket_2 = 'image-sized-1' # your-destination-bucket
-sns_topic_arn = 'arn:aws:sns:ap-south-1:804937851364:image-resizing-topic' # your-sns-topic
+SOURCE_BUCKET = "image-non-sized-1"  # your-source-bucket
+DESTINATION_BUCKET = "image-sized-1"  # your-destination-bucket
+SNS_TOPIC_ARN = "arn:aws:sns:ap-south-1:804937851364:image-resizing-topic"  # your-sns-topic
 
-def lambda_handler(event, context):
-    if 'Records' in event:
-        # Handle S3 batch event
-        for record in event['Records']:
-            handle_s3_record(record)
-    else:
-        # Handle single S3 event
-        handle_s3_record(event)
-
-def handle_s3_record(record):
-    # Ensure the event record structure is correct
-    if 's3' in record and 'bucket' in record['s3'] and 'name' in record['s3']['bucket'] and 'object' in record['s3'] and 'key' in record['s3']['object']:
-        # Get the bucket name and object key from the S3 event record
-        source_bucket = record['s3']['bucket']['name']
-        object_key = record['s3']['object']['key']
-
-        # Download the file from S3 bucket_1
-        response = s3.get_object(Bucket=source_bucket, Key=object_key)
-        content_type = response['ContentType']
-        image_data = response['Body'].read()
-
-        # Resize and compress the image
-        resized_image = resize_and_compress_image(image_data)
-
-        # Upload the resized and compressed image to S3 bucket_2
-        destination_key = f"resized/{object_key}"
-        s3.put_object(Bucket=bucket_2, Key=destination_key, Body=resized_image, ContentType=content_type)
-
-        # Send a notification to the SNS topic
-        message = f"Image {object_key} has been resized and uploaded to {bucket_2}"
-        sns.publish(TopicArn=sns_topic_arn, Message=message)
-    else:
-        # Log an error message if the event record structure is unexpected
-        print("Error: Invalid S3 event record structure")
+# Maximum size for the longest image edge. Images smaller than the constraint
+# keep their original dimensions.
+MAX_DIMENSION = (1280, 1280)
 
 
-def resize_and_compress_image(image_data, quality=75):
-    # Open the image using PIL
-    image = Image.open(BytesIO(image_data))
+def lambda_handler(event, context):  # pylint: disable=unused-argument
+    """Entry point for the Lambda function."""
 
-    # Compress the image
-    image_io = BytesIO()
-    image.save(image_io, format=image.format, quality=quality)
+    records = event.get("Records") if isinstance(event, dict) else None
+    if not records:
+        records = [event]
 
-    return image_io.getvalue()
+    for record in records:
+        try:
+            source_bucket, object_key = _extract_s3_info(record)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            logger.error("Unable to parse S3 event record: %s", exc)
+            continue
+
+        if SOURCE_BUCKET and source_bucket != SOURCE_BUCKET:
+            logger.info(
+                "Skipping object %s from unexpected bucket %s", object_key, source_bucket
+            )
+            continue
+
+        try:
+            image_bytes, content_type = _download_s3_object(source_bucket, object_key)
+        except ClientError:
+            logger.exception("Failed to download %s from %s", object_key, source_bucket)
+            continue
+
+        try:
+            stylized_bytes, output_content_type, transformation = stylize_image(
+                image_bytes,
+                source_content_type=content_type,
+            )
+        except OSError as exc:  # pragma: no cover - guard for unsupported images
+            logger.exception("Failed to process image %s: %s", object_key, exc)
+            continue
+
+        destination_key = f"stylized/{object_key}"
+
+        _upload_stylized_image(destination_key, stylized_bytes, output_content_type)
+        _publish_stylize_notification(object_key, destination_key, transformation)
+
+
+def _extract_s3_info(record: dict) -> Tuple[str, str]:
+    """Extract the S3 bucket name and object key from an event record."""
+
+    if not isinstance(record, dict):
+        raise ValueError("Record is not a dictionary")
+
+    s3_info = record.get("s3") or {}
+    bucket_info = s3_info.get("bucket") or {}
+    object_info = s3_info.get("object") or {}
+
+    bucket_name = bucket_info.get("name")
+    object_key = object_info.get("key")
+
+    if not bucket_name or not object_key:
+        raise ValueError("Missing S3 bucket name or object key")
+
+    return bucket_name, object_key
+
+
+def _download_s3_object(bucket: str, key: str) -> Tuple[bytes, str]:
+    """Download an object from S3 and return its bytes and content type."""
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    body = response["Body"].read()
+    content_type = response.get("ContentType", "application/octet-stream")
+    return body, content_type
+
+
+def stylize_image(
+    image_data: bytes,
+    *,
+    source_content_type: Optional[str] = None,
+    quality: int = 80,
+    max_dimension: Tuple[int, int] = MAX_DIMENSION,
+) -> Tuple[bytes, str, str]:
+    """Transform an image into a cartoon or colorized rendition.
+
+    The function analyses the input image to determine whether it is grayscale
+    or colored. Grayscale photos are colorized using a warm/cool duotone palette
+    while colored photos receive a stylized cartoon treatment. The longest edge
+    is constrained by ``max_dimension`` to keep output sizes manageable.
+    """
+
+    with BytesIO(image_data) as input_buffer, Image.open(input_buffer) as image:
+        image_format = (image.format or _content_type_to_format(source_content_type)).upper()
+        image = ImageOps.exif_transpose(image)
+
+        if image.mode in {"RGBA", "LA", "P"}:
+            rgba_image = image.convert("RGBA")
+            alpha_channel = rgba_image.split()[-1]
+            working_image = rgba_image.convert("RGB")
+        else:
+            alpha_channel = None
+            working_image = image.convert("RGB")
+
+        _constrain_size(working_image, max_dimension)
+        if alpha_channel is not None and alpha_channel.size != working_image.size:
+            alpha_channel = alpha_channel.resize(working_image.size, Image.LANCZOS)
+
+        if _is_grayscale(working_image):
+            stylized_rgb = _colorize_grayscale(working_image)
+            transformation = "colorized"
+        else:
+            stylized_rgb = _cartoonize(working_image)
+            transformation = "cartoonized"
+
+        if alpha_channel is not None:
+            stylized = stylized_rgb.convert("RGBA")
+            stylized.putalpha(alpha_channel)
+        else:
+            stylized = stylized_rgb
+
+        output_buffer = BytesIO()
+        save_kwargs = {"format": image_format}
+
+        if image_format in {"JPEG", "JPG"}:
+            stylized = stylized.convert("RGB")
+            save_kwargs.update({"quality": quality, "optimize": True, "progressive": True})
+        elif image_format == "PNG":
+            stylized = stylized.convert("RGBA")
+            save_kwargs.update({"optimize": True, "compress_level": 9})
+        else:
+            stylized = stylized.convert("RGB")
+
+        stylized.save(output_buffer, **save_kwargs)
+        output_bytes = output_buffer.getvalue()
+
+    return (
+        output_bytes,
+        _format_to_content_type(image_format, source_content_type),
+        transformation,
+    )
+
+
+def _upload_stylized_image(object_key: str, data: bytes, content_type: str) -> None:
+    """Upload the stylized image to the destination bucket."""
+
+    s3.put_object(Bucket=DESTINATION_BUCKET, Key=object_key, Body=data, ContentType=content_type)
+
+
+def _publish_stylize_notification(original_key: str, destination_key: str, transformation: str) -> None:
+    """Send a notification to SNS once the image has been stylized."""
+
+    message = (
+        f"Image {original_key} has been {transformation} and uploaded to {DESTINATION_BUCKET}"
+        f" as {destination_key}"
+    )
+    sns.publish(TopicArn=SNS_TOPIC_ARN, Message=message)
+
+
+def _constrain_size(image: Image.Image, max_dimension: Tuple[int, int]) -> None:
+    """Resize an image in-place so its longest edge does not exceed ``max_dimension``."""
+
+    image.thumbnail(max_dimension, Image.LANCZOS)
+
+
+def _is_grayscale(image: Image.Image) -> bool:
+    """Return ``True`` if the provided image has no color information."""
+
+    if image.mode in {"1", "L", "LA"}:
+        return True
+
+    converted = image.convert("RGB") if image.mode != "RGB" else image
+
+    r, g, b = converted.split()
+    return (
+        ImageChops.difference(r, g).getbbox() is None
+        and ImageChops.difference(r, b).getbbox() is None
+    )
+
+
+def _cartoonize(image: Image.Image) -> Image.Image:
+    """Apply a cartoon-like stylization to a color image."""
+
+    base = image.convert("RGB")
+
+    # Smooth gradients while keeping overall structure.
+    smooth = base.filter(ImageFilter.SMOOTH_MORE).filter(ImageFilter.SMOOTH_MORE)
+
+    # Reduce the number of colors to create flat color regions typical of cartoons.
+    reduced = smooth.quantize(colors=48, method=Image.MEDIANCUT).convert("RGB")
+
+    # Detect edges and enhance them to create bold outlines.
+    edges = base.convert("L")
+    edges = edges.filter(ImageFilter.MedianFilter(size=3)).filter(ImageFilter.FIND_EDGES)
+    edges = ImageOps.invert(edges)
+    edges = ImageOps.autocontrast(edges, cutoff=10)
+    edges = edges.point(lambda x: 255 if x > 110 else 0)
+    edges = ImageOps.invert(edges).convert("RGB")
+
+    # Combine the color-reduced image with the edge mask for the cartoon look.
+    cartoon = ImageChops.multiply(reduced, edges)
+    return ImageOps.autocontrast(cartoon, cutoff=2)
+
+
+def _colorize_grayscale(image: Image.Image) -> Image.Image:
+    """Colorize a grayscale image with a balanced warm and cool palette."""
+
+    grayscale = image.convert("L")
+    grayscale = ImageOps.autocontrast(grayscale, cutoff=5)
+
+    # Apply a duotone colorization with cooler shadows and warm highlights.
+    colorized = ImageOps.colorize(
+        grayscale,
+        black="#1f2a44",
+        white="#f5d7af",
+        mid="#6b9ac4",
+    )
+    enhancer = ImageEnhance.Color(colorized)
+    return enhancer.enhance(1.15)
+
+
+def _format_to_content_type(image_format: str, fallback: Optional[str]) -> str:
+    """Return the MIME type for a Pillow image format."""
+
+    mime_type = Image.MIME.get(image_format)
+    if mime_type:
+        return mime_type
+    return fallback or "application/octet-stream"
+
+
+def _content_type_to_format(content_type: Optional[str]) -> str:
+    """Infer a Pillow format from a MIME type."""
+
+    if not content_type:
+        return "JPEG"
+
+    for format_name, mime in Image.MIME.items():
+        if mime == content_type:
+            return format_name
+
+    return "JPEG"


### PR DESCRIPTION
## Summary
- build a React single-page application that collects AWS credentials, manages upload preferences, and surfaces activity and results for the stylization Lambda
- implement an in-browser SigV4 S3 client and workflow hook to upload images, poll for stylized outputs, and stream the finished asset back into the UI
- document the new frontend workflow and prerequisites so the UI can be launched alongside the existing Lambda automation

## Testing
- python -m compileall image-resizing-s3.py
- npm install *(fails: registry returned 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2244ccd80832f991d70dc752b062a